### PR TITLE
Added important block for registering the Azure quota provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,59 @@ This module uses the AzAPI provider to query the Azure Quota REST API to obtain 
 
 https://learn.microsoft.com/en-us/rest/api/quota/quota/get?view=rest-quota-2023-02-01&tabs=HTTP
 <!-- BEGIN_TF_DOCS -->
+
+> [!IMPORTANT]
+>
+> Azure subscriptions are not enabled with the `Microsoft.Quota` resource provider by default.
+>
+> If you do not have Microsoft.Quota enabled, you will encounter a message like this.
+>
+> ```
+> --------------------------------------------------------------------------------
+> RESPONSE 400: 400 Bad Request
+> ERROR CODE: MissingRegistrationForResourceProvider
+> --------------------------------------------------------------------------------
+>  {
+>    "error": {
+>      "code": "MissingRegistrationForResourceProvider",
+>      "message": "The subscription is not in registered state for the resource provider: Microsoft.Quota."
+>    }
+>  }
+> --------------------------------------------------------------------------------
+> ```
+>
+> Use the following Azure CLI command to check if your subscription has the Quota provider enabled.
+>
+> ```bash
+> az provider list --query "[?namespace=='Microsoft.Quota']" --output table
+> Namespace        RegistrationState    RegistrationPolicy
+> ---------------  -------------------  --------------------
+> Microsoft.Quota  NotRegistered        RegistrationRequired
+> ```
+>
+> If your subscription <u>does not</u> have the `Microsoft.Quota` provider enabled, then use this command to enable it:
+>
+> ```bash
+> az provider register --namespace Microsoft.Quota
+> ```
+>
+> Registration of the provider in Azure may take some time. 
+>
+> Use this command to check to see the status of the  provider registration.
+>
+> ```bash
+> az provider list --query "[?namespace=='Microsoft.Quota']" --output table
+> Namespace        RegistrationState    RegistrationPolicy
+> ---------------  -------------------  --------------------
+> Microsoft.Quota  Registering          RegistrationRequired
+> 
+> 
+> az provider list --query "[?namespace=='Microsoft.Quota']" --output table
+> Namespace        RegistrationState    RegistrationPolicy
+> ---------------  -------------------  --------------------
+> Microsoft.Quota  Registered           RegistrationRequired
+> ```
+
 ## Requirements
 
 | Name | Version |


### PR DESCRIPTION
Added an "Important" MarkDown block in the README.md file to inform the users of the module that they might need to register the `Microsoft.Quota` provider along with the Azure CLI commands to register the provider and to check the provider's status in the Azure subscription.